### PR TITLE
Button Mapping Forgetting `type`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,7 @@
     "sourceType": "module"
   },
   "rules": {
-    "semi": ["always"],
+    "semi": 1,
     // don't force es6 functions to include space before paren
     "space-before-function-paren": 0,
 

--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,8 @@ export class ShepherdTour extends Component {
             return {
               action: tour[type],
               classes,
-              text
+              text,
+              type
             }
           }
         )


### PR DESCRIPTION
#23 Ensuring that the button `type` is including in the mapping of the buttons during tour initialization.

https://github.com/shipshapecode/react-shepherd/issues/23