### PR TITLE
Add prebuild script and tsconfig to generate declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "test": "cross-env CI=1 react-scripts test",
     "test:watch": "react-scripts test",
+    "prebuild": "tsc --project ./tsconfig-declarations.json",
     "build": "rollup -c",
     "start": "rollup -c -w",
     "prepare": "yarn run build",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "dist/Shepherd.js",
   "module": "dist/Shepherd.es.js",
   "jsnext:main": "dist/Shepherd.es.js",
+  "types": "dist/index.d.ts",
   "homepage": "https://shipshapecode.github.io/react-shepherd/",
   "engines": {
     "node": ">=8",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,9 @@ const addSteps = (steps: Array<Step> | Array<Step.StepOptions>, tour: Tour) => {
       step.buttons = buttons.map((button: ShepherdStepWithType) => {
         const { type, classes, text, action } = button;
         return {
-          action: action || tour[type],
+          // TypeScript doesn't have great support for dynamic method calls with
+          // bracket notation, so we use the `any` escape hatch
+          action: action || (tour as any)[type!],
           classes,
           text,
           type

--- a/tsconfig-declarations.json
+++ b/tsconfig-declarations.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": false,
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true
+  }
+}


### PR DESCRIPTION
Resolves #41 

Relevant issues:
* https://github.com/microsoft/TypeScript/issues/29490 (`emitDeclaration` is not compatible with `isolatedModules`, which is already set in the base `tsconfig.json`, so an alternate config was needed)
* https://github.com/rollup/rollup-plugin-typescript/issues/54 (`rollup-plugin-typescript` doesn't support generating declarations, so we have to use `tsc` itself to generate the declarations)

Caveats:
* Not really loving the use of `!` and `any`, but this seems to be something that can only be resolved with 1. some refactoring of types in the upstream shepherd library or 2. some sort of explicit string check (e.g. `if (type === 'next') action = tour.next`) which means that every time you add a new action type to the base library, you need to add another check here, which I think goes against the spirit of this being a very lightweight, mostly independent-of-upstream wrapper, but let me know your thoughts

Alternative solutions:
* `rollup-plugin-typescript2` seems to support generating declarations, so we could also try upgrading