### PR TITLE
Manage secondary property on Step button

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "dependencies": {
-    "shepherd.js": "^8.0.0"
+    "shepherd.js": "^8.0.2"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,9 +5,6 @@ import Tour from 'shepherd.js/src/types/tour';
 
 interface ShepherdButtonWithType extends Step.StepOptionsButton {
   type?: string;
-  // Shepherd.js `StepOptionsButton` interface is missing `secondary` props.
-  // Adding this property here until the PR (https://github.com/shipshapecode/shepherd/pull/1040) is merged.
-  secondary?: boolean;
 }
 
 interface ShepherdOptionsWithType extends Step.StepOptions {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,9 @@ import Tour from 'shepherd.js/src/types/tour';
 
 interface ShepherdButtonWithType extends Step.StepOptionsButton {
   type?: string;
+  // Shepherd.js `StepOptionsButton` interface is missing `secondary` props.
+  // Adding this property here until the PR (https://github.com/shipshapecode/shepherd/pull/1040) is merged.
+  secondary?: boolean;
 }
 
 interface ShepherdOptionsWithType extends Step.StepOptions {
@@ -36,7 +39,7 @@ const addSteps = (steps: Array<Step.StepOptions>, tour: Tour) => {
 
     if (buttons) {
       step.buttons = buttons.map((button: ShepherdButtonWithType) => {
-        const { action, classes, disabled, label, text, type } = button;
+        const { action, classes, disabled, label, secondary, text, type } = button;
         return {
           // TypeScript doesn't have great support for dynamic method calls with
           // bracket notation, so we use the `any` escape hatch
@@ -44,6 +47,7 @@ const addSteps = (steps: Array<Step.StepOptions>, tour: Tour) => {
           classes,
           disabled,
           label,
+          secondary,
           text,
           type
         };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1515,10 +1515,10 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@popperjs/core@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.0.tgz#0e1bdf8d021e7ea58affade33d9d607e11365915"
-  integrity sha512-NMrDy6EWh9TPdSRiHmHH2ye1v5U0gBD7pRYwSwJvomx7Bm4GG04vu63dYiVzebLOx2obPpJugew06xVP0Nk7hA==
+"@popperjs/core@^2.4.4":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
+  integrity sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==
 
 "@sheerun/mutationobserver-shim@^0.3.2", "@sheerun/mutationobserver-shim@^0.3.3":
   version "0.3.3"
@@ -10475,12 +10475,12 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shepherd.js@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/shepherd.js/-/shepherd.js-8.0.0.tgz#50e49e3788e9689aa5ca04e5c42d9e5e49715a28"
-  integrity sha512-ni/gC892prp0vqg3L/SByOnJMFtnQVBHSs1VtvR2FS+tHD/WzH8bX5dRAqQ/LWTv8BGi8UbKHQAPs+FHB/gg/Q==
+shepherd.js@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/shepherd.js/-/shepherd.js-8.0.2.tgz#30675a68883c474b5c7b4056b98f2423b577708f"
+  integrity sha512-qFt5vrnVoshg6fS5gKGQznYGyIaEclyKKSl1Siw6gO7GyKnCEJ2aBDrp8pxKusMfZo5J5dtgeKJtsRav5cimjA==
   dependencies:
-    "@popperjs/core" "^2.4.0"
+    "@popperjs/core" "^2.4.4"
     deepmerge "^4.2.2"
     smoothscroll-polyfill "^0.4.4"
 


### PR DESCRIPTION
Hello,

The TypeScript definition of `StepOptionsButton` in Shepherd core JS is missing the `secondary` property. I've made a [PR](https://github.com/shipshapecode/shepherd/pull/1040) to solve this issue.

One _real_ impact is that the property is ignored by `react-shepherd` library. This PR fixes that.
