### PR TITLE
update example step definition in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ const steps = [
     classes: 'custom-class-name-1 custom-class-name-2',
     highlightClass: 'highlight',
     scrollTo: false,
-    showCancelLink: true,
+    cancelIcon: {
+      enabled: true,
+    },
     title: 'Welcome to React-Shepherd!',
     text: ['React-Shepherd is a JavaScript library for guiding users through your React app.'],
     when: {


### PR DESCRIPTION
Fix `steps` example. 
`showCancelLink` has been renamed to `cancelIcon`: https://github.com/shipshapecode/shepherd/search?q=showCancelLink&unscoped_q=showCancelLink