### PR TITLE
🐛 Remove check for current action assignment

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,11 +36,11 @@ const addSteps = (steps: Array<Step.StepOptions>, tour: Tour) => {
 
     if (buttons) {
       step.buttons = buttons.map((button: ShepherdButtonWithType) => {
-        const { action, classes, disabled, label, secondary, text, type } = button;
+        const { classes, disabled, label, secondary, text, type } = button;
         return {
           // TypeScript doesn't have great support for dynamic method calls with
           // bracket notation, so we use the `any` escape hatch
-          action: action || (tour as any)[type!],
+          action: (tour as any)[type!],
           classes,
           disabled,
           label,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,11 +36,11 @@ const addSteps = (steps: Array<Step.StepOptions>, tour: Tour) => {
 
     if (buttons) {
       step.buttons = buttons.map((button: ShepherdButtonWithType) => {
-        const { classes, disabled, label, secondary, text, type } = button;
+        const { action, classes, disabled, label, secondary, text, type } = button;
         return {
           // TypeScript doesn't have great support for dynamic method calls with
           // bracket notation, so we use the `any` escape hatch
-          action: (tour as any)[type!],
+          action: (tour as any)[type!] || action,
           classes,
           disabled,
           label,


### PR DESCRIPTION
If there's a condition to rerender the tour, which will create a new ID/instance, but the steps don't change, then the bound function for button types doesn't update from the initial instance. 