### PR TITLE
Fix attachTo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You must pass an array of steps to `steps`, something like this:
 const steps = [
   {
     id: 'intro',
-    attachTo: '.first-element bottom',
+    attachTo: { element: '.first-element', on: 'bottom' },
     beforeShowPromise: function () {
       return new Promise(function (resolve) {
         setTimeout(function () {


### PR DESCRIPTION
The `attachTo` parameters seem to be wrong / out-of-sync with the Shepherd JS implementation.

This changes fixes it for me.