### PR TITLE
Upgrade shepherd dependency to minimum version 10

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -28,7 +28,7 @@
     "test:watch": "react-scripts test"
   },
   "dependencies": {
-    "shepherd.js": "^8.3.1"
+    "shepherd.js": "^10.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",


### PR DESCRIPTION
### Problem

Users experiencing same background opacity issue with latest chrome update as main `shepherd` package
- Also see: [Issue](https://github.com/shipshapecode/shepherd/issues/1941) & [PR](https://github.com/shipshapecode/shepherd/pull/1942)

### Findings

Current lib is configured for a minimum shepherd version 8.3.1. Any shepherd version below 10 will experience the background opacity issue at load on the most recent version of chrome.

### Solution

Upgrade react-wrapped lib to shepherd version 10 that includes a bugfix for this as covered in the PR above

closes #640 