### PR TITLE
Add optional children prop on ShepherdProps typescript index `React18`

### DIFF
--- a/packages/lib/src/index.tsx
+++ b/packages/lib/src/index.tsx
@@ -14,6 +14,7 @@ export interface ShepherdOptionsWithType extends Step.StepOptions {
 interface ShepherdProps {
   steps: Array<ShepherdOptionsWithType>;
   tourOptions: Tour.TourOptions;
+  children?: React.ReactNode;
 }
 
 const ShepherdTourContext = React.createContext<Tour | null>(null);


### PR DESCRIPTION
### Problem:

`React 18` no longer supports automatic children property

### Solution:

Write in optional children property for lib source type definition