### PR TITLE
Upgrade to react 18

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -83,8 +83,8 @@
     "typescript": "^4.0.2"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^17.0.2 || 18.x",
+    "react-dom": "^17.0.0 || 18.x"
   },
   "engines": {
     "node": ">=14",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -84,7 +84,7 @@
   },
   "peerDependencies": {
     "react": "^17.0.2 || 18.x",
-    "react-dom": "^17.0.0 || 18.x"
+    "react-dom": "^17.0.2 || 18.x"
   },
   "engines": {
     "node": ">=14",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -83,8 +83,8 @@
     "typescript": "^4.0.2"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "engines": {
     "node": ">=14",


### PR DESCRIPTION
### Problem

Node 7 and above automatic installation of **peerDepedencies** causes errors on package install due to the current peerDependency limitation to React 17.

Users wish to avoid the use of `--legacy-peer-deps` flag.

### Solution

Open up peerDependency for react to include both 17 and 18 along with react-dom

Closes #638 